### PR TITLE
removed protocol from jQuery URL to support both HTTP and HTTPS URLs for...

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 		<!--
 		<link crossorigin href="http://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" rel="stylesheet">
 		-->
-		<script src="http://code.jquery.com/jquery.js"></script>
+		<script src="//code.jquery.com/jquery.js"></script>
 		<script type="text/javascript" src="bootstrap/js/bootstrap.js"></script>		
 	
 		<script src="js/modernizr-latest.js" type="text/javascript"></script>

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 var LoadingIssuesList = new Array();
 var DebugOn = false;
+var $ = jQuery;
+
 // usage: log('inside coolFunc',this,arguments);
 // http://paulirish.com/2009/log-a-lightweight-wrapper-for-consolelog/
 // added this logging function from paul irish to debug if needed.


### PR DESCRIPTION
... Mantis. Specified $ var for jQuery since there were error messages in Google Chrome regarding mising $ variable.
