### PR TITLE
Bug fix of Issue #51. Hosting Mantis on HTTPS.

### DIFF
--- a/js/kanban.js
+++ b/js/kanban.js
@@ -1006,7 +1006,7 @@ function EditStory(storyID) {
 
 	var thisStory = Kanban.GetStoryByFieldValue("ID", storyID);
 	/// Thanks to todace for sample code https://github.com/todace
-	document.getElementById("edit-story-title").innerHTML = "<a target=\"_new\" href=http://" + Mantis.ServerHostname + "/view.php?id=" + thisStory.ID + ">"+ thisStory.ID + "</a> &nbsp; " + (thisStory.Summary.length > 40 ? thisStory.Summary.substring(0, 37) + "..." : thisStory.Summary);
+	document.getElementById("edit-story-title").innerHTML = "<a target=\"_new\" href=" + Mantis.ServerHostname + "/view.php?id=" + thisStory.ID + ">"+ thisStory.ID + "</a> &nbsp; " + (thisStory.Summary.length > 40 ? thisStory.Summary.substring(0, 37) + "..." : thisStory.Summary);
 	//document.getElementById("edit-story-title").innerHTML = "Edit Story: " + thisStory.ID + " " + (thisStory.Summary.length > 40 ? thisStory.Summary.substring(0, 37) + "..." : thisStory.Summary);
 	//$("#edit-story-form").dialog({ title: "Edit Story: " + thisStory.ID + " " + (thisStory.Summary.length > 40 ? thisStory.Summary.substring(0, 37) + "..." : thisStory.Summary) });
 	$("#edit-story-id").val(thisStory.ID);


### PR DESCRIPTION
Bug fix of Issue #51. Hosting Mantis on HTTPS gave wrong href links in edit view.

When hosting Mantis on a HTTPS server and configuring the ServerHostName in config.js as Mantis.ServerHostname = "https://my.host/mantis", the title link into Mantis for an issue shown in the "View Issue" right side popup are wrong.

The edit-story-title HTML item will show a faulty href to "https//my.host/mantis" (tested in Firefox).

This fix removes the "http://" from target since it is specified by the Mantis.ServerHostname .
