### PR TITLE
Allow mantisURL to be empty.

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,7 +156,12 @@ function Login() {
 	log("Login() called.");
 	
 	document.getElementById("username").focus();
-	Mantis.ConnectURL = document.getElementById("mantisURL").value;
+	
+	if ( "" == document.getElementById("mantisURL").value ) {
+		document.getElementById("mantisURL").value = Mantis.ConnectURL;
+	} else {
+		Mantis.ConnectURL = document.getElementById("mantisURL").value;
+	}
 	
 	try {
 		var retObj = Mantis.Login(document.getElementById("username").value, document.getElementById("password").value);


### PR DESCRIPTION
When mantisURL is empty. The connection URL will be read from
Mantis.ConnectURL in config.js. In order to facilitate first time login.

Zipher