### PR TITLE
Fix error custom_fields not defined

### DIFF
--- a/js/kanbanclasses.js
+++ b/js/kanbanclasses.js
@@ -284,23 +284,27 @@ KanbanStory.prototype = {
 	},
 
 	get Tasks() {
-		for(var iq = 0; iq < this.StorySource.custom_fields.length; iq++) {
-			var customField = this.StorySource.custom_fields[iq];
-			if(customField.field.name == Mantis.TaskListField) {
-				if(this.StorySource.custom_fields[iq].value == null) {
-				 return [];
-				} else {
-					return JSON.parse(this.StorySource.custom_fields[iq].value);
+		if (Kanban.UsingCustomField) {
+			for(var iq = 0; iq < this.StorySource.custom_fields.length; iq++) {
+				var customField = this.StorySource.custom_fields[iq];
+				if(customField.field.name == Mantis.TaskListField) {
+					if(this.StorySource.custom_fields[iq].value == null) {
+					 return [];
+					} else {
+						return JSON.parse(this.StorySource.custom_fields[iq].value);
+					}
 				}
 			}
 		}
 		return [];
 	},
 	set Tasks(value) {
-		for(var iq = 0; iq < this.StorySource.custom_fields.length; iq++) {
-			var customField = this.StorySource.custom_fields[iq];
-			if(customField.field.name == Mantis.TaskListField) {
-				this.StorySource.custom_fields[iq].value = JSON.stringify(value);
+		if (Kanban.UsingCustomField) {
+			for(var iq = 0; iq < this.StorySource.custom_fields.length; iq++) {
+				var customField = this.StorySource.custom_fields[iq];
+				if(customField.field.name == Mantis.TaskListField) {
+					this.StorySource.custom_fields[iq].value = JSON.stringify(value);
+				}
 			}
 		}
 	},


### PR DESCRIPTION
In kanbanclasses.js, get Tasks reported error when there is no custom field
defined in MantisBT. A check to variable UsingCustomField is added before
read the length of custom field.